### PR TITLE
Chore/implement auditable entities

### DIFF
--- a/lawyerSystem.api/Core/Interfaces/IAuditableEntity.cs
+++ b/lawyerSystem.api/Core/Interfaces/IAuditableEntity.cs
@@ -1,0 +1,8 @@
+﻿namespace lawyerSystem.api.Domain.Interfaces;
+
+public interface IAuditableEntity
+{
+    public DateTime CreatedAt { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+}

--- a/lawyerSystem.api/lawyerSystem.api.csproj
+++ b/lawyerSystem.api/lawyerSystem.api.csproj
@@ -16,7 +16,6 @@
     <Folder Include="Core\Dtos\" />
     <Folder Include="Core\Mappers\" />
     <Folder Include="Core\Services\" />
-    <Folder Include="Core\Interfaces\" />
     <Folder Include="Infrastructure\Configurations\" />
   </ItemGroup>
 


### PR DESCRIPTION
# Description

This PR introduces an automatic mechanism to manage ```createAt``` and ```updateAt``` timestamps for entities, ensuring data consistency and reducing boilerplate code

The implementation overrides the ```DbContext.SaveChangesAsync()``` method. before saving any changes to the database, it automatically inspects all tracket entities. If any entity implements the ```IAuditableEntity``` interface, its timestamp fields are set according to its state:

- On **creation** (```EntityState.Added```), both ```createAt``` and ```updateAt``` are set on the current UTC time.
- On **modification** (```EntityState.Modified```), only ```updateAt``` is updated.

## Itens Created

- Created **IAuditableEntity** to lead with SaveChange and inicializate the constructor
- Created **UpdateAuditFields()** function to use in service and only use the dependencies

## Itens Changed
- Overrided the SaveChangesAsync to put UpdateAuditFields() inside this function and make this work every update or create that is saved in database